### PR TITLE
Let Git tell us if we're in a repo

### DIFF
--- a/git-update
+++ b/git-update
@@ -14,7 +14,8 @@ function failure() {
   exit 1
 }
 
-if [ ! -d .git ]; then
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+
   failure "You must run this command from inside a git repository"
 fi
 


### PR DESCRIPTION
Allow git-update to be run from anywhere in a repository, rather than only in
the root of the repository where `.git/` exists.
