### PR TITLE
Exit git-update when a command fails

### DIFF
--- a/git-update
+++ b/git-update
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 green="\033[32m"
 red="\033[31m"
 color_reset="\033[0m"


### PR DESCRIPTION
`set -e` in sh will exit immediately when a command fails and isn't
handled:

```
    -e      Exit immediately if a pipeline (which may consist  of  a
            single  simple command),  a subshell command enclosed in
            parentheses, or one of the commands executed as part  of
            a  command  list  enclosed  by braces (see SHELL GRAMMAR
            above) exits with a non-zero status.  The shell does not
            exit  if  the  command that fails is part of the command
            list immediately following a  while  or  until  keyword,
            part  of  the  test  following  the  if or elif reserved
            words, part of any command executed in a && or  ││  list
            except  the  command  following  the final && or ││, any
            command in a pipeline but the last, or if the  command’s
            return  value  is being inverted with !.  A trap on ERR,
            if set, is executed before the shell exits.  This option
            applies to the shell environment and each subshell envi-
            ronment separately (see  COMMAND  EXECUTION  ENVIRONMENT
            above), and may cause subshells to exit before executing
            all the commands in the subshell.
```

Which means that where before when a branch had diverged from upstream
and `git pull` couldn't successfully resolve the merge on its own, we
would be told that we had successfully completed a `git update` and left
in the middle of a rebase:

```
my-awesome-project(feature-branch<>) ❯ git update
Both local and remote branches have moved on. Branch 'feature-branch' needs to be rebased onto 'calebthompson/feature-branch'
error: could not apply b469094... conflicting change

When you have resolved this problem, run "git rebase --continue".
If you prefer to skip this patch, run "git rebase --skip" instead.
To check out the original branch and stop rebasing, run "git rebase --abort".

Recorded preimage for 'file_with_changes.txt'
Could not pick b46909490cd2fd839ca044aef49f7b5f44f06cdf
* 2f5a7de (calebthompson/feature-branch) conflicting change - Caleb Thompson (4 minutes ago)
* cb3413d cool new feature - Caleb Thompson (17 hours ago)
All good
my-awesome-project(feature-branch *+|REBASE-i 2/2) ❯
```

However now we are at least dumped out directly into the rebase (this
change does mean that we no longer get the log output for what was
pulled or a success message):

```
my-awesome-project(feature-branch<>) ❯ git update
Both local and remote branches have moved on. Branch 'feature-branch' needs to be rebased onto 'calebthompson/feature-branch'
error: could not apply b469094... concflicting change

When you have resolved this problem, run "git rebase --continue".
If you prefer to skip this patch, run "git rebase --skip" instead.
To check out the original branch and stop rebasing, run "git rebase --abort".

Recorded preimage for 'file_with_changes.txt'
Could not pick b46909490cd2fd839ca044aef49f7b5f44f06cdf
my-awesome-project(feature-branch *+|REBASE-i 2/2) ❯
```
