### PR TITLE
Stashing local changes triggers GPG sign with commit.gpgsign=true

### DIFF
--- a/git-update
+++ b/git-update
@@ -47,7 +47,7 @@ fi
 __git_update_stash () {
   if git status --short | egrep 'M|A|D|UU'; then
     echo "Stashing local changes"
-    git stash
+    git -c commit.gpgsign=false stash
     stashed_changes=true
   fi
 }


### PR DESCRIPTION
Whenever pulling in fresh changes, if I need to stash as part of `git-update` my config causes the stash commit to be signed, meaning I need to unlock my secret key.

I don't care if a stash commit is signed, ever. Thoughts on overriding that value with something like

`git -c "commit.gpgsign=false" stash`?