### PR TITLE
Parse the remote sha _after_ pulling

### DIFF
--- a/git-update
+++ b/git-update
@@ -5,7 +5,6 @@ set -e
 upstream_branch=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}")
 
 head_sha=$(git rev-parse HEAD)
-remote_sha=$(git rev-parse "$upstream_branch")
 
 __git_update_prettyprint_log () {
   format=$(
@@ -17,4 +16,7 @@ __git_update_prettyprint_log () {
 }
 
 git pull --rebase=preserve --autostash
+
+remote_sha=$(git rev-parse "$upstream_branch")
+
 __git_update_prettyprint_log


### PR DESCRIPTION
Previously, we were parsing the remote sha out of the upstream branch
before pulling. This meant that when we later went to print a log of the
changes since that sha, it resulted in a no-op because our remote hadn't
moved on yet.

The simplest fix for this is to parse the remote sha after we perform
our pull, and right before we want to print the log.

/cc @calebthompson