### PR TITLE
preserve was replaced by merges

### DIFF
--- a/git-update
+++ b/git-update
@@ -15,7 +15,7 @@ __git_update_prettyprint_log () {
   git log --format="$format" --graph "$merge_base_sha".."$remote_sha"
 }
 
-git pull --rebase=preserve --autostash
+git pull --rebase=merges --autostash
 
 remote_sha=$(git rev-parse "$upstream_branch")
 


### PR DESCRIPTION
❯ git pull --rebase=preserve
    error: preserve: 'preserve' superseded by 'merges'
    error: Invalid value for --rebase: preserve

git-rebase also renamed `--preserve-merges` to `--rebase-merges`.